### PR TITLE
Write output into contract_name.wasm and contract_name.sha256

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build publish run debug
 
-DOCKER_TAG := 0.6.2
+DOCKER_TAG := 0.6.3
 CODE ?= "/path/to/contract"
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ optimization on the build size, using `wasm-pack` and `wasm-opt`.
 
 The easiest way is to simply use the [published docker image](https://hub.docker.com/r/confio/cosmwasm-opt).
 You must set the local path to the smart contract you wish to compile and
-it will produce a `contract.wasm` file in the same directory.
+it will produce a `contract_name.wasm` and a `contract_name.sha256` file in the same directory.
 
 Run it a few times on different computers
 and use `sha256sum` to prove to yourself that this is consistent. I challenge
@@ -21,7 +21,7 @@ you to produce a smaller build that works with the cosmwasm integration tests
 docker run --rm -v $(pwd):/code \
   --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  confio/cosmwasm-opt:0.6.2
+  confio/cosmwasm-opt:0.6.3
 ```
 
 Note that we use one registry cache (to avoid excessive downloads), but the target cache is a different volume per

--- a/optimize.sh
+++ b/optimize.sh
@@ -11,9 +11,13 @@ echo "Building contract in $(realpath -m "$contractdir")"
 
 (
   cd "$contractdir"
+
+  contract_name=$(grep --extended-regexp -e 'name\s*=\s*"([-_a-zA-Z0-9]+)"' Cargo.toml | cut -d= -f2 | tr -dc "\-_a-zA-Z0-9")
+  echo "Found contract name $contract_name"
+
   wasm-pack build --release --out-dir "${outdir}" -- --locked
-  wasm-opt -Os "${outdir}"/*.wasm -o contract.wasm
-  sha256sum contract.wasm > hash.txt
+  wasm-opt -Os "${outdir}"/*.wasm -o "$contract_name.wasm"
+  sha256sum "$contract_name.wasm" > "$contract_name.sha256"
   cargo run --example schema
 )
 


### PR DESCRIPTION
This becomes handy when copying the contract files somewhere else