### PR TITLE
Avoid building schema during optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build publish run debug
 
-DOCKER_TAG := 0.7.0
+DOCKER_TAG := 0.7.1
 CODE ?= "/path/to/contract"
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ you to produce a smaller build that works with the cosmwasm integration tests
 docker run --rm -v $(pwd):/code \
   --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  confio/cosmwasm-opt:0.7.0
+  confio/cosmwasm-opt:0.7.1
 ```
 
 Note that we use one registry cache (to avoid excessive downloads), but the target cache is a different volume per

--- a/optimize.sh
+++ b/optimize.sh
@@ -14,10 +14,6 @@ echo "Building contract in $(realpath -m "$contractdir")"
   wasm-pack build --release --out-dir "${outdir}" -- --locked
   wasm-opt -Os "${outdir}"/*.wasm -o contract.wasm
   sha256sum contract.wasm > hash.txt
-
-  # Is this necessary here? This step takes a long time because it compiles all devDependencies, including the whole VM.
-  echo "Rebuilding schema ..."
-  cargo run --example schema
 )
 
 echo "done"


### PR DESCRIPTION
The core of cosmwasm-opt is to build a small `contract.wasm` in a reproducible way. Re-generating the schema files is something that should be done by the developer or a CI system. The main problem with this is that it takes a very long time since it needs to build the `devDependencies` of the contract project. This is a burden not only for the contract developer but also when you verify a build.

Also our documentation suggests to

1. Regenerate schema using `cargo schema`
2. Create optimized build using cosmwasm-opt

which makes sense in my opinion.