### PR TITLE
Avoid using web-pack by doing the stripping directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM trzeci/emscripten:1.39.8-fastcomp
 
 # Note: I tried slim and had issues compiling wasm-pack, even with --features vendored-openssl
-FROM rust:1.41.0
+FROM rust:1.41.1
 
 # setup rust with wasm-pack
 RUN rustup target add wasm32-unknown-unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,8 @@ FROM trzeci/emscripten:1.39.8-fastcomp
 # Note: I tried slim and had issues compiling wasm-pack, even with --features vendored-openssl
 FROM rust:1.41.1
 
-# setup rust with wasm-pack
+# setup rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown
-
-# I'd rather not
-# RUN cargo install wasm-pack --version 0.9.1
-RUN curl -L -sSf https://github.com/rustwasm/wasm-pack/releases/download/v0.9.1/wasm-pack-v0.9.1-x86_64-unknown-linux-musl.tar.gz > wasm-pack.tar.gz
-RUN tar xzf wasm-pack.tar.gz
-RUN cp wasm-pack-*-x86_64-unknown-linux-musl/wasm-pack /usr/local/bin
-
-# cleanup
-RUN rm -rf wasm-*
 
 # copy wasm-opt into our path
 COPY --from=0 /emsdk_portable/binaryen/bin/wasm-opt /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build publish run debug
 
-DOCKER_TAG := 0.7.1
+DOCKER_TAG := 0.7.2
 CODE ?= "/path/to/contract"
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a Docker build with a locked set of dependencies to produce
 reproducible builds of cosmwasm smart contracts. It also does heavy
-optimization on the build size, using `wasm-pack` and `wasm-opt`.
+optimization on the build size, using binary stripping and `wasm-opt`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ you to produce a smaller build that works with the cosmwasm integration tests
 docker run --rm -v $(pwd):/code \
   --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  confio/cosmwasm-opt:0.7.1
+  confio/cosmwasm-opt:0.7.2
 ```
 
 Note that we use one registry cache (to avoid excessive downloads), but the target cache is a different volume per

--- a/optimize.sh
+++ b/optimize.sh
@@ -3,7 +3,7 @@ set -o errexit -o nounset -o pipefail
 command -v shellcheck > /dev/null && shellcheck "$0"
 
 export PATH=$PATH:/root/.cargo/bin
-outdir=$(mktemp -d)
+
 # This parameter allows us to mount a folder into docker container's "/code"
 # and build "/code/contracts/mycontract".
 contractdir="$1"
@@ -11,8 +11,11 @@ echo "Building contract in $(realpath -m "$contractdir")"
 
 (
   cd "$contractdir"
-  wasm-pack build --release --out-dir "${outdir}" -- --locked
-  wasm-opt -Os "${outdir}"/*.wasm -o contract.wasm
+
+  # Linker flag "-s" for stripping (https://github.com/rust-lang/cargo/issues/3483#issuecomment-431209957)
+  RUSTFLAGS='-C link-arg=-s' cargo wasm --locked
+  wasm-opt -Os target/wasm32-unknown-unknown/release/*.wasm -o contract.wasm
+
   sha256sum contract.wasm > hash.txt
 )
 


### PR DESCRIPTION
This avoids the need of wasm-bindgen dependency in contracts